### PR TITLE
GH-14 Add update checker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ If you find any bugs, issues or inconsistencies, kindly report them [here](https
 
 LobbyHeads offers two permissions for administrators to assign:
 
-| Permission           | Description                                                     |
-|:---------------------|:----------------------------------------------------------------|
-| `lobbyheads.replace` | Allows the user to replace decorative heads whenever they want. |
-| `lobbyheads.admin`   | Grants the user permission to add or remove decorative heads.   |
+| Permission                  | Description                                                                     |
+|:----------------------------|:--------------------------------------------------------------------------------|
+| `lobbyheads.replace`        | Allows the user to replace decorative heads whenever they want.                 |
+| `lobbyheads.admin`          | Grants the user permission to add or remove decorative heads.                   |
+| `lobbyheads.receiveupdates` | Grants the user permission to receive updates about new versions of the plugin. |
 
 ## Usage Guidelines
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ repositories {
     maven { url = uri("https://hub.spigotmc.org/nexus/content/repositories/snapshots/") }
     maven { url = uri("https://jitpack.io") }
     maven { url = uri("https://repo.extendedclip.com/content/repositories/placeholderapi/") }
+    maven { url = uri("https://repo.eternalcode.pl/releases") }
     maven { url = uri("https://storehouse.okaeri.eu/repository/maven-public/") }
     maven { url = uri("https://repository.minecodes.pl/releases") }
     maven { url = uri("https://libraries.minecraft.net/") }
@@ -65,6 +66,9 @@ dependencies {
 
     // bstats
     implementation("org.bstats:bstats-bukkit:3.0.2")
+
+    // GitCheck
+    implementation("com.eternalcode:gitcheck:1.0.0")
 
     // tests setup
     testImplementation("org.codehaus.groovy:groovy-all:3.0.19")
@@ -115,9 +119,9 @@ tasks.shadowJar {
     archiveFileName.set("LobbyHeads v${project.version}.jar")
 
     exclude(
-            "org/intellij/lang/annotations/**",
-            "org/jetbrains/annotations/**",
-            "META-INF/**",
+        "org/intellij/lang/annotations/**",
+        "org/jetbrains/annotations/**",
+        "META-INF/**",
     )
 
     dependsOn("checkstyleMain")
@@ -128,12 +132,13 @@ tasks.shadowJar {
 
     val prefix = "com.eternalcode.lobbyheads.libs"
     listOf(
-            "dev.rollczi",
-            "eu.okaeri",
-            "panda",
-            "org.yaml",
-            "net.kyori",
-            "com.github.unldenis",
-            "org.bstats",
+        "dev.rollczi",
+        "eu.okaeri",
+        "panda",
+        "org.yaml",
+        "net.kyori",
+        "com.github.unldenis",
+        "org.bstats",
+        "com.eternalcode.gitcheck",
     ).forEach { relocate(it, prefix) }
 }

--- a/src/main/java/com/eternalcode/lobbyheads/HeadsPlugin.java
+++ b/src/main/java/com/eternalcode/lobbyheads/HeadsPlugin.java
@@ -16,6 +16,8 @@ import com.eternalcode.lobbyheads.head.hologram.HologramService;
 import com.eternalcode.lobbyheads.head.particle.ParticleController;
 import com.eternalcode.lobbyheads.head.sound.SoundController;
 import com.eternalcode.lobbyheads.notification.NotificationAnnouncer;
+import com.eternalcode.lobbyheads.updater.UpdaterNotificationController;
+import com.eternalcode.lobbyheads.updater.UpdaterService;
 import dev.rollczi.liteskullapi.LiteSkullFactory;
 import dev.rollczi.liteskullapi.SkullAPI;
 import net.kyori.adventure.platform.AudienceProvider;
@@ -55,6 +57,8 @@ public class HeadsPlugin extends JavaPlugin {
             .build();
 
         NotificationAnnouncer notificationAnnouncer = new NotificationAnnouncer(this.audienceProvider, miniMessage);
+        UpdaterService updaterService = new UpdaterService(this.getDescription());
+
 
         HeadRepository headRepository = new HeadRepositoryImpl(config, configurationService);
 
@@ -75,7 +79,10 @@ public class HeadsPlugin extends JavaPlugin {
             new SoundController(server, config),
             new ParticleController(server, config),
             new BlockController(this, server.getScheduler(), this.skullAPI),
-            new HologramController(hologramService, config, server)
+            new HologramController(hologramService, config, server),
+
+            // check-up-to-date
+            new UpdaterNotificationController(updaterService, config, notificationAnnouncer)
         ).forEach(listener -> server.getPluginManager().registerEvents(listener, this));
 
         new Metrics(this, 20048);

--- a/src/main/java/com/eternalcode/lobbyheads/configuration/implementation/HeadsConfiguration.java
+++ b/src/main/java/com/eternalcode/lobbyheads/configuration/implementation/HeadsConfiguration.java
@@ -27,6 +27,9 @@ public class HeadsConfiguration extends OkaeriConfig implements DelaySettings {
     @Comment("# Delay between replacing heads")
     public Duration headReplacementDelay = Duration.ofSeconds(15);
 
+    @Comment({ " ", "# Update check" })
+    public boolean receivePluginUpdates = true;
+
     @Comment({ " ", "# Heads list, don't touch this!" })
     public List<Head> heads = new ArrayList<>();
 

--- a/src/main/java/com/eternalcode/lobbyheads/updater/UpdaterNotificationController.java
+++ b/src/main/java/com/eternalcode/lobbyheads/updater/UpdaterNotificationController.java
@@ -1,0 +1,50 @@
+package com.eternalcode.lobbyheads.updater;
+
+import com.eternalcode.lobbyheads.configuration.implementation.HeadsConfiguration;
+import com.eternalcode.lobbyheads.notification.NotificationAnnouncer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+import java.util.concurrent.CompletableFuture;
+
+public class UpdaterNotificationController implements Listener {
+
+    private static final String NEW_VERSION_AVAILABLE = "<b><gradient:#ff14dc:#c814ff>LobbyHeads:</gradient></b> <color:#ff00e1>New version of LobbyHeads is available, please update!";
+
+    private final UpdaterService updaterService;
+    private final HeadsConfiguration config;
+    private final NotificationAnnouncer notificationAnnouncer;
+
+    public UpdaterNotificationController(UpdaterService updaterService, HeadsConfiguration config,
+                                         NotificationAnnouncer notificationAnnouncer) {
+        this.updaterService = updaterService;
+        this.config = config;
+        this.notificationAnnouncer = notificationAnnouncer;
+    }
+
+    @EventHandler
+    void onJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+
+        if (!player.hasPermission("lobbyheads.receiveupdates") || !this.config.receivePluginUpdates) {
+            return;
+        }
+
+        CompletableFuture<Boolean> upToDate = this.updaterService.isUpToDate();
+
+        upToDate.whenComplete((isUpToDate, throwable) -> {
+            if (throwable != null) {
+                throwable.printStackTrace();
+
+                return;
+            }
+
+            if (!isUpToDate) {
+                this.notificationAnnouncer.sendMessage(player, NEW_VERSION_AVAILABLE);
+            }
+        });
+    }
+
+}

--- a/src/main/java/com/eternalcode/lobbyheads/updater/UpdaterService.java
+++ b/src/main/java/com/eternalcode/lobbyheads/updater/UpdaterService.java
@@ -1,0 +1,29 @@
+package com.eternalcode.lobbyheads.updater;
+
+import com.eternalcode.gitcheck.GitCheck;
+import com.eternalcode.gitcheck.GitCheckResult;
+import com.eternalcode.gitcheck.git.GitRepository;
+import com.eternalcode.gitcheck.git.GitTag;
+import org.bukkit.plugin.PluginDescriptionFile;
+
+import java.util.concurrent.CompletableFuture;
+
+public class UpdaterService {
+
+    private static final GitRepository GIT_REPOSITORY = GitRepository.of("EternalCodeTeam", "LobbyHeads");
+
+    private final GitCheck gitCheck = new GitCheck();
+    private final CompletableFuture<GitCheckResult> gitCheckResult;
+
+    public UpdaterService(PluginDescriptionFile descriptionFile) {
+        this.gitCheckResult = CompletableFuture.supplyAsync(() -> {
+            String version = descriptionFile.getVersion();
+            return this.gitCheck.checkRelease(GIT_REPOSITORY, GitTag.of("v" + version));
+        });
+    }
+
+    public CompletableFuture<Boolean> isUpToDate() {
+        return this.gitCheckResult.thenApply(GitCheckResult::isUpToDate);
+    }
+
+}


### PR DESCRIPTION
I added a permission update checker (`lobbyheads.receiveupdates`) without a Lazy implementation like in EternalCombat. I don't want to add expressible for just the updater.

Fixes #14 