### PR TITLE
GH-25 Fix null profile.

### DIFF
--- a/src/main/java/com/eternalcode/lobbyheads/head/block/BlockController.java
+++ b/src/main/java/com/eternalcode/lobbyheads/head/block/BlockController.java
@@ -67,7 +67,7 @@ public class BlockController implements Listener {
     }
 
     private void updateSkull(SkullData skullData, Skull skull) {
-        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), null);
+        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), "");
         gameProfile.getProperties().put(SKULL_TEXTURE_PROPERTY_KEY,
             new Property(SKULL_TEXTURE_PROPERTY_KEY, skullData.getValue()));
 


### PR DESCRIPTION
```
[20:57:01 WARN]: [LobbyHeads] Task #430 for LobbyHeads v1.0.2 generated an exception
java.lang.NullPointerException: Profile name must not be null
at java.util.Objects.requireNonNull(Objects.java:233) ~[?:?]
at com.mojang.authlib.GameProfile.<init>(GameProfile.java:31) ~[authlib-5.0.47.jar:?]
at com.eternalcode.lobbyheads.head.block.BlockController.updateSkull(BlockController.java:70) ~[LobbyHeads.v1.0.2.jar:?]
at com.eternalcode.lobbyheads.head.block.BlockController.lambda$prepareSkullUpdate$0(BlockController.java:66) ~[LobbyHeads.v1.0.2.jar:?]
at org.bukkit.craftbukkit.v1_20_R2.scheduler.CraftTask.run(CraftTask.java:101) ~[paper-1.20.2.jar:git-Paper-318]
at org.bukkit.craftbukkit.v1_20_R2.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:480) ~[paper-1.20.2.jar:git-Paper-318]
at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1470) ~[paper-1.20.2.jar:git-Paper-318]
at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:446) ~[paper-1.20.2.jar:git-Paper-318]
at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1379) ~[paper-1.20.2.jar:git-Paper-318]
at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1156) ~[paper-1.20.2.jar:git-Paper-318]
at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:315) ~[paper-1.20.2.jar:git-Paper-318]
at java.lang.Thread.run(Thread.java:833) ~[?:?]

```